### PR TITLE
Fix Docker pull command formatting in cd-pipeline.yml

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -186,9 +186,7 @@ jobs:
             **Autor:** ${{ github.actor }}
 
             ### Imagen Docker
-```bash
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/entregaya:latest
-```
           files: target/*.jar
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Removed bash code block formatting from Docker pull command in the CI pipeline.

